### PR TITLE
Revert "fuzz: Build with -mavx2"

### DIFF
--- a/.clusterfuzzlite/build.sh
+++ b/.clusterfuzzlite/build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -eu
 
 autoreconf -i
-./configure --disable-dependency-tracking CFLAGS="-g -O2 -mavx2"
+./configure --disable-dependency-tracking
 make -j$(nproc)
 
 $CXX $CXXFLAGS -std=c++17 -I. \


### PR DESCRIPTION
This reverts commit 0d664673eadb26a46b1d4073fbeabc1921f81662.

Batch fuzzing (undefined) does not work with this option.